### PR TITLE
Fixed space_added_updated

### DIFF
--- a/push2github
+++ b/push2github
@@ -12,7 +12,7 @@ space_added_updated() {
     # Assumption: directory changes at most once every 15 minutes otherwise only the first 
     # changed space will appear in the commit message
     
-    echo $(git diff directory.json | egrep -m 1 -o  "\+[[:space:]]+.+\:[[:space:]]" | cut -d'"' -f2)  
+    echo $(git diff directory.json | egrep -o "\+[[:space:]]+.+\:[[:space:]]" | tail -n1 | cut -d'"' -f2)  
 }
 
 commit() {


### PR DESCRIPTION
When a new hackerspace gets added, the previously entered
hackerspace will be "updated", because a comma gets appended
to the entry.
This patch should show the actually changed hackerspace in
the commit message (instead of the unchanged previously
entered space). It should also work if an existing hackerspace
is changed.

I did not test this!
