### PR TITLE
Update MetaMeute: migrate https to http

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -13,7 +13,7 @@
     "HeatSync Labs": "http://intranet.heatsynclabs.org/~access/cgi-bin/spaceapi.rb",
     "Hickerspace": "http://hickerspace.org/api/info/",
     "Le Loop": "http://spaceapi.net/cache/Le+Loop",
-    "MetaMeute": "https://status.metameute.de/spaceapi.json",
+    "MetaMeute": "http://status.metameute.de/spaceapi.json",
     "Make, Hack, Void Canberra": "http://space.makehackvoid.com/status",
     "Makers Local 256": "https://256.makerslocal.org/status.json",
     "MidsouthMakers": "http://midsouthmakers.org/spaceapi/",


### PR DESCRIPTION
Log from #spaceapi:

```
<Jamalaka> hey
<Jamalaka> Since the last update of the android app we have problems updating via https
<Jamalaka> could you please change https:\/\/status.metameute.de\/spaceapi.json to http:\/\/status.metameute.de\/spaceapi.json ?
<rohieb> Jamalaka: hmmm. we should probably ask the people from metameute if that is okay
<rohieb> apparently they use CAcert
<Jamalaka> rohieb: I am part of the MetaMeute.
```
