### PR TITLE
Update Directory - remove old entry

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -9,7 +9,6 @@
     "Garoa Hacker Clube": "https://garoahc.appspot.com/status",
     "Hack42": "http://hack42.nl/spacestate/json.php",
     "Hackburg": "http://www.hackburg.ch/status.json",
-    "Hackspace-Jena": "http://status.hackspace-jena.de/api/",
     "HeatSync Labs": "http://members.heatsynclabs.org/space_api.json",
     "Hickerspace": "http://hickerspace.org/api/info/",
     "Le Loop": "http://spaceapi.net/cache/Le+Loop",


### PR DESCRIPTION
remove old entry for hackspace-jena. The new one is krautspace.
