### PR TITLE
update SpaceAPI for Coredump.ch

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -3,6 +3,7 @@
     "ACKspace": "https://ackspace.nl/status.php",
     "Beta-Space": "http://status.kreativitaet-trifft-technik.de/status.json",
     "Bitlair": "https://bitlair.nl/statejson.php",
+    "Coredump": "https://status.crdmp.ch/",
     "Farset Labs": "http://spaceapi.net/cache/Farset+Labs",
     "FIXME": "https://fixme.ch/cgi-bin/spaceapi.py",
     "Frack": "http://frack.nl/spacestate/?api",


### PR DESCRIPTION
Coredump.ch has moved the SpaceAPI:
`https://status.coredump.ch/` => `https://status.crdmp.ch/`
